### PR TITLE
Add APIs from POSIX and the BSDs

### DIFF
--- a/Optional.h
+++ b/Optional.h
@@ -24,7 +24,8 @@ Message tokens: None
 History:
   CJB: 25-Apr-25: New header file.
   CJB: 03-May-25: Added strtod, strstr and strchr.
-  ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush.
+  ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
+                  reallocarray.
 */
 
 #ifndef Optional_h
@@ -80,6 +81,15 @@ static inline _Optional void *optional_realloc(_Optional void *p, size_t n)
 }
 #undef realloc
 #define realloc(p, n) optional_realloc(p, n)
+
+#if __has_include(<unistd.h>)  // If we're on a POSIX system.
+static inline _Optional void *optional_reallocarray(_Optional void *p, size_t n, size_t sz)
+{
+    return reallocarray((void *)p, n, sz);
+}
+# undef reallocarray
+# define reallocarray(p, n, sz) optional_reallocarray(p, n, sz)
+#endif
 
 static inline long optional_strtol(const char * restrict str, char *_Optional * restrict str_end, int base)
 {

--- a/Optional.h
+++ b/Optional.h
@@ -25,7 +25,7 @@ History:
   CJB: 25-Apr-25: New header file.
   CJB: 03-May-25: Added strtod, strstr and strchr.
   ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
-                  reallocarray.
+                  reallocarray, and freezero.
   ACA: 10-Aug-25: Add getgroups.
 */
 
@@ -64,6 +64,15 @@ static inline void optional_free(_Optional void *x)
 }
 #undef free
 #define free(x) optional_free(x)
+
+#if __has_include(<readpassphrase.h>)  // If we're on a BSD system.
+static inline void optional_freezero(_Optional void *p, size_t n)
+{
+    freezero((void *)p, n);
+}
+# undef freezero
+# define freezero(p, n) optional_freezero(p, n)
+#endif
 
 static inline _Optional void *optional_malloc(size_t n)
 {

--- a/Optional.h
+++ b/Optional.h
@@ -26,6 +26,7 @@ History:
   CJB: 03-May-25: Added strtod, strstr and strchr.
   ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
                   reallocarray.
+  ACA: 10-Aug-25: Add getgroups.
 */
 
 #ifndef Optional_h
@@ -36,6 +37,9 @@ History:
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#if __has_include(<unistd.h>)
+# include <unistd.h>
+#endif
 
 #undef NULL
 #define NULL ((_Optional void *)0)
@@ -118,6 +122,15 @@ static inline _Optional char *optional_strchr(const char *str, int ch)
 }
 #undef strchr
 #define strchr(str, ch) optional_strchr(str, ch)
+
+#if __has_include(<unistd.h>)
+static inline int optional_getgroups(size_t n, _Optional gid_t gids[n])
+{
+    return getgroups(n, (gid_t *) gids);
+}
+# undef getgroups
+# define getgroups(n, gids)  optional_getgroups(n, gids)
+#endif
 
 #else
 #define _Optional


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v2</summary>

-  Fix setgroups().
-  Add getgroups().

```
$ git range-diff iso..gh/posix cjb/main..posix 
1:  d90bcbe = 1:  ec9845c Optional.h: reallocarray(): Add wrapper
2:  799f8da ! 2:  87bb837 Optional.h: setgroups(): Add wrapper
    @@ Optional.h: static inline _Optional char *optional_strchr(const char *str, int c
     +#if __has_include(<grp.h>)
     +static inline int optional_setgroups(size_t n, _Optional const gid_t gids[n])
     +{
    -+    return setgroups(n, gids);
    ++    return setgroups(n, (const gid_t *) gids);
     +}
     +# undef setgroups
     +# define setgroups(n, gids) optional_setgroups(n, gids)
-:  ------- > 3:  4371e89 Optional.h: getgroups(): Add wrapper
3:  8ec1627 ! 4:  7ac9c5e Optional.h: freezero(): Add wrapper
    @@ Optional.h: History:
        ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
     -                  reallocarray, setgroups.
     +                  reallocarray, setgroups, and freezero.
    +   ACA: 10-Aug-25: Add getgroups.
      */
      
    - #ifndef Optional_h
     @@ Optional.h: static inline void optional_free(_Optional void *x)
      #undef free
      #define free(x) optional_free(x)
```
</details>

<details>
<summary>v3</summary>

-  Drop setgroups(2).

```
$ git range-diff cjb/main gh/posix posix 
1:  ec9845c = 1:  ec9845c Optional.h: reallocarray(): Add wrapper
2:  87bb837 < -:  ------- Optional.h: setgroups(): Add wrapper
3:  4371e89 ! 2:  0e848e8 Optional.h: getgroups(): Add wrapper
    @@ Optional.h
     @@ Optional.h: History:
        CJB: 03-May-25: Added strtod, strstr and strchr.
        ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
    -                   reallocarray, setgroups.
    +                   reallocarray.
     +  ACA: 10-Aug-25: Add getgroups.
      */
      
    @@ Optional.h: static inline _Optional char *optional_strchr(const char *str, int c
     +# define getgroups(n, gids)  optional_getgroups(n, gids)
     +#endif
     +
    - #if __has_include(<grp.h>)
    - static inline int optional_setgroups(size_t n, _Optional const gid_t gids[n])
    - {
    + #else
    + #define _Optional
    + #endif
4:  7ac9c5e ! 3:  faba320 Optional.h: freezero(): Add wrapper
    @@ Optional.h: History:
        CJB: 25-Apr-25: New header file.
        CJB: 03-May-25: Added strtod, strstr and strchr.
        ACA: 09-Aug-25: Fix the calloc macro's parameter list.  Add fflush,
    --                  reallocarray, setgroups.
    -+                  reallocarray, setgroups, and freezero.
    +-                  reallocarray.
    ++                  reallocarray, and freezero.
        ACA: 10-Aug-25: Add getgroups.
      */
      
```
</details>